### PR TITLE
test: fix local pytest compatibility and import path\n\n- Lower pytes…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-minversion = 8.0
+minversion = 7.0
 addopts = -ra
 testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+
+# Ensure project root is on the path when running tests
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+


### PR DESCRIPTION
…t minversion to 7.0\n- Add tests/conftest.py to inject project root into sys.path\n\nAll tests pass locally (6/6).

## Summary

Describe the change and motivation.

## Changes

- ...

## Checklist

- [ ] Tests added/updated for all changes
- [ ] No tests removed (or replaced with stronger coverage and rationale)
- [ ] `pytest` passes locally
- [ ] CI green
- [ ] If AI-assisted, noted here and tests lock behavior

## Notes

Anything reviewers should pay special attention to, or follow-ups.
