### PR TITLE
feat(shop): deterministic lootbox shop + open command\n\n- Add engine…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,11 @@ on:
 
 jobs:
   test:
-    name: Tests (Python ${{ matrix.python-version }} • ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Tests (Windows • Python ${{ matrix.python-version }})
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12"]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -714,3 +714,22 @@ The river glints. Which fish do you snag?
 
 See CONTRIBUTING.md for guidelines. In short: always add tests with changes; do not remove tests; if AI-assisted, include tests that lock behavior.
 
+
+---
+
+## CI (GitHub Actions)
+
+CI runs pytest on Windows only. See .github/workflows/ci.yml.
+
+---
+
+## Lootboxes & Shop (Deterministic)
+
+- The shop sells 1–3 lootboxes per cycle (per player), deterministically seeded (Clash Royale-style rotating offers).
+- Lootboxes open into deterministic rewards with exponential scaling by tier (absurd numbers encouraged). Numeric logic stays LLM-free.
+- Commands:
+  - shop — show current offers
+  - uy <n> — purchase offer 
+
+  - open <n> — open nth lootbox in your inventory
+

--- a/astrarpg/engine/loot.py
+++ b/astrarpg/engine/loot.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from .generation import rng_for
+from .models import Item, Player
+
+
+@dataclass(frozen=True)
+class LootBox:
+    code: str
+    name: str
+    tier: int
+    price: int
+
+
+# A small pool to start; expand easily
+POOL: List[LootBox] = [
+    LootBox("copper", "Copper Cache", 1, 5),
+    LootBox("tin", "Tin Trove", 1, 9),
+    LootBox("iron", "Iron Hoard", 2, 20),
+    LootBox("silver", "Silver Reliquary", 2, 35),
+    LootBox("gold", "Gilded Reliquary", 3, 60),
+    LootBox("obs", "Obsidian Reliquary", 3, 90),
+    LootBox("myth", "Mythril Reliquary", 4, 140),
+    LootBox("eld", "Elder Reliquary", 5, 220),
+    LootBox("abyss", "Abyssal Reliquary", 6, 360),
+    LootBox("void", "Void Reliquary", 7, 580),
+    LootBox("star", "Starborn Reliquary", 8, 900),
+    LootBox("apex", "Apex Reliquary", 9, 1400),
+]
+
+
+def shop_offers(pid: str, cycle: str = "daily") -> List[LootBox]:
+    """Deterministic 1-3 offers from the pool, based on player and cycle.
+
+    cycle may be a date string (YYYY-MM-DD) or any caller-supplied tag.
+    """
+    r = rng_for("shop", pid, cycle)
+    count = 1 + r.randint(0, 2)  # 1..3
+    # Select distinct boxes
+    idxs = list(range(len(POOL)))
+    picks: List[LootBox] = []
+    for _ in range(count):
+        i = r.randint(0, len(idxs) - 1)
+        picks.append(POOL[idxs.pop(i)])
+    # Sort by price for stable display order
+    picks.sort(key=lambda b: b.price)
+    return picks
+
+
+def open_box(pid: str, box: LootBox, salt: str = "") -> List[Item]:
+    """Deterministic rewards based on player, box, and salt."""
+    r = rng_for("loot", pid, box.code, box.tier, salt)
+    # Scale absurdly over time: simple exponential-ish growth by tier
+    base = 1 + box.tier
+    pow_mult = 2 ** max(0, box.tier - 1)
+    # Roll 1-3 items
+    k = 1 + r.randint(0, 2)
+    items: List[Item] = []
+    for _ in range(k):
+        roll = r.randint(0, 99)
+        if roll < 60:
+            items.append(Item(name="Scrap", power=base * pow_mult))
+        elif roll < 90:
+            items.append(Item(name="Curio", power=base * pow_mult * 3))
+        else:
+            items.append(Item(name="Relic", power=base * pow_mult * 7))
+    return items
+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -42,3 +42,16 @@ def test_zone_map_travel():
     _, _ = dispatch(gs, "travel n")
     msg_after, _ = dispatch(gs, "map")
     assert msg_before != msg_after
+
+
+def test_shop_buy_open():
+    gs = make_state()
+    gs.player.gold = 1000
+    msg, done = dispatch(gs, "shop")
+    assert "Shop offers" in msg and not done
+    # Attempt to buy first offer
+    msg, _ = dispatch(gs, "buy 1")
+    assert "Purchased" in msg
+    # Opening first lootbox in inventory listing
+    msg, _ = dispatch(gs, "open 1")
+    assert "clicks open" in msg

--- a/tests/test_loot_shop.py
+++ b/tests/test_loot_shop.py
@@ -1,0 +1,16 @@
+from astrarpg.engine.loot import shop_offers, open_box, LootBox
+from astrarpg.engine.models import Item
+
+
+def test_shop_offers_deterministic():
+    a = shop_offers("p1", cycle="2025-09-10")
+    b = shop_offers("p1", cycle="2025-09-10")
+    assert a == b and 1 <= len(a) <= 3
+
+
+def test_open_box_deterministic():
+    box = LootBox(code="iron", name="Iron Hoard", tier=2, price=0)
+    r1 = open_box("p1", box, salt="x")
+    r2 = open_box("p1", box, salt="x")
+    assert [i.name for i in r1] == [i.name for i in r2]
+    assert all(isinstance(i, Item) for i in r1)


### PR DESCRIPTION
….loot with lootbox pool, shop offers, and open logic\n- Wire 'shop', 'buy', 'open' commands\n- Tests: loot shop + command flow\n- CI: Windows-only matrix\n- README: add shop/loot notes and CI note

## Summary

Describe the change and motivation.

## Changes

- ...

## Checklist

- [ ] Tests added/updated for all changes
- [ ] No tests removed (or replaced with stronger coverage and rationale)
- [ ] `pytest` passes locally
- [ ] CI green
- [ ] If AI-assisted, noted here and tests lock behavior

## Notes

Anything reviewers should pay special attention to, or follow-ups.
